### PR TITLE
no-location-href-assign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /node_modules
 *.swp
+*.log
+.idea

--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ Then configure the rules you want to use under the rules section.
 ## Supported Rules
 
 * [xss/no-mixed-html](docs/rules/no-mixed-html.md): Warn about possible XSS issues.
+* [xss/no-location-href-assign](docs/rules/no-location-href-assign.md): Warn when trying to modify location.href.
 

--- a/docs/rules/no-location-href-assign.md
+++ b/docs/rules/no-location-href-assign.md
@@ -1,18 +1,18 @@
-# Checks for all assignments to location.href (prevents javascript url based XSS)
+# Checks for all assignments to location.href
 
-Wanted a way to catch XSS issues in code before they end up in production.
+This rule ensures that you are calling escape logic before assigning to location.href property.
 
 ## Rule Details
 
-This rule tries to prevent XSS that can be created by passing user input directly to
+This rule tries to prevent XSS that can be created by assigning some user input directly to
 location.href property. Here is an example of how we can execute any js code in that way;
 
 ```js
-window.location.href = 'javascript:alert('xss')'
+window.location.href = 'javascript:alert("xss")'
 ```
 
 
-The following patterns are considered warnings:
+The following patterns are considered as errors:
 
 ```js
 
@@ -23,7 +23,7 @@ location.href = getNextUrl();
 
 ```
 
-The following patterns are not warnings:
+The following patterns are not errors:
 
 ```js
 // this rule ensures that you are calling escape function before location.href assignment
@@ -36,7 +36,7 @@ location.href = escape('some evil url');
 
 ```js
 "xss/no-mixed-html": [ 2, {
-    "escapeFunc": "escape"
+    "escapeFunc": "escapeHref"
 } ];
 ```
 
@@ -46,7 +46,7 @@ Function name that is used to sanitize user input. 'escape' is used by default.
 
 ## When Not To Use It
 
-If you are not care about XSS vulnerabilities.
+When you are running your code outside of browser environment (node) or you don't care about XSS vulnerabilities.
 
 ## Further Reading
 

--- a/docs/rules/no-location-href-assign.md
+++ b/docs/rules/no-location-href-assign.md
@@ -31,6 +31,7 @@ The following patterns are not errors:
 location.href = escape('some evil url');
 
 ```
+The concrete implementation of escape is up to you and how you will decide to escape location.href value.
 
 ### Options
 

--- a/docs/rules/no-location-href-assign.md
+++ b/docs/rules/no-location-href-assign.md
@@ -31,7 +31,8 @@ The following patterns are not errors:
 location.href = escape('some evil url');
 
 ```
-The concrete implementation of escape is up to you and how you will decide to escape location.href value.
+The concrete implementation of escape is up to you and how you will decide to escape location.href value. This rule
+only ensures that you are handling assignment in a proper way (by wrapping the right part with the escape function).
 
 ### Options
 

--- a/docs/rules/no-location-href-assign.md
+++ b/docs/rules/no-location-href-assign.md
@@ -1,0 +1,53 @@
+# Checks for all assignments to location.href (prevents javascript url based XSS)
+
+Wanted a way to catch XSS issues in code before they end up in production.
+
+## Rule Details
+
+This rule tries to prevent XSS that can be created by passing user input directly to
+location.href property. Here is an example of how we can execute any js code in that way;
+
+```js
+window.location.href = 'javascript:alert('xss')'
+```
+
+
+The following patterns are considered warnings:
+
+```js
+
+window.location.href = 'some evil user content';
+document.location.href = 'some evil user content';
+location.href = 'some evil user content';
+location.href = getNextUrl();
+
+```
+
+The following patterns are not warnings:
+
+```js
+// this rule ensures that you are calling escape function before location.href assignment
+// 'escape' name can be configured via options.
+location.href = escape('some evil url');
+
+```
+
+### Options
+
+```js
+"xss/no-mixed-html": [ 2, {
+    "escapeFunc": "escape"
+} ];
+```
+
+### escapeFunc (optional)
+Function name that is used to sanitize user input. 'escape' is used by default.
+
+
+## When Not To Use It
+
+If you are not care about XSS vulnerabilities.
+
+## Further Reading
+
+- [XSS Prevention CHeat Sheet - OWASP](https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet)

--- a/lib/rules/no-location-href-assign.js
+++ b/lib/rules/no-location-href-assign.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview prevents xss by assignment to location href javascript url string
+ * @author Alexander Mostovenko
+ */
+'use strict';
+
+
+// ------------------------------------------------------------------------------
+// Plugin Definition
+// ------------------------------------------------------------------------------
+
+var ERROR = 'Dangerous location.href assignment can lead to XSS';
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'disallow location.href assignment (prevent possible XSS)'
+        },
+    },
+    create: function( context ) {
+        var escapeFunc = context.options[ 0 ] &&
+            context.options[ 0 ].escapeFunc || 'escape';
+
+        return {
+            AssignmentExpression: function( node ) {
+                var left = node.left;
+                var isHref = left.property && left.property.name === 'href';
+                if( !isHref ) {
+                    return;
+                }
+                var isLocationObject = left.object && left.object.name === 'location';
+                var isLocationProperty = left.object.property &&
+					left.object.property.name === 'location';
+
+                if( !( isLocationObject || isLocationProperty ) ) {
+                    return;
+                }
+
+                if( node.right.callee && node.right.callee.name === escapeFunc ) {
+                    return;
+                }
+                var sourceCode = context.getSourceCode();
+                var rightSource = sourceCode.getText( node.right );
+                var errorMsg = ERROR +
+                    '. Please use ' + escapeFunc +
+                    '(' + rightSource + ') as a wrapper for escaping';
+
+                context.report( { node: node, message: errorMsg } );
+            }
+        };
+    }
+};
+
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "Mikko Rantanen",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha tests --recursive"
+    "test": "mocha tests --recursive",
+    "lint": "eslint ./lib ./tests/"
   },
   "dependencies": {
     "requireindex": "~1.1.0"

--- a/tests/lib/rules/no-location-href-assign.js
+++ b/tests/lib/rules/no-location-href-assign.js
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview checks rule that prevents xss by assignment
+ * to location href javascript url string
+ * @author Alexander Mostovenko
+ */
+'use strict';
+
+var rule = require( '../../../lib/rules/no-location-href-assign' ),
+    RuleTester = require( 'eslint' ).RuleTester;
+
+var ruleTester = new RuleTester();
+ruleTester.run( 'no-location-href-assign', rule, {
+
+    valid: [
+        'someLink.href = \'www\'',
+        'href = \'wwww\'',
+        {
+            code: 'location.href = escape(\'www\')',
+            options: [ { escapeFunc: 'escape' } ]
+        }
+    ],
+
+    invalid: [
+        {
+            code: 'location.href = wrapper(escape(\'www\'))',
+            options: [ { escapeFunc: 'escapeXSS' } ],
+            errors: [ {
+                message: 'Dangerous location.href assignment can lead to XSS.' +
+                ' Please use escapeXSS(wrapper(escape(\'www\'))) ' +
+                'as a wrapper for escaping'
+            } ]
+        },
+        {
+            code: 'location.href = wrapper(\'www\')',
+            options: [ { escapeFunc: 'escape' } ],
+            errors: [ {
+                message: 'Dangerous location.href assignment can lead to XSS.' +
+                ' Please use escape(wrapper(\'www\')) as a wrapper for escaping'
+            } ]
+        },
+        {
+            code: 'location.href = \'some location\'',
+            errors: [ {
+                message: 'Dangerous location.href assignment can lead to XSS.' +
+                    ' Please use escape(\'some location\') as a wrapper for escaping'
+            } ]
+        },
+        {
+            code: 'window.location.href = \'some location\'',
+            errors: [ {
+                message: 'Dangerous location.href assignment can lead to XSS.' +
+                    ' Please use escape(\'some location\') as a wrapper for escaping'
+            } ]
+        },
+        {
+            code: 'document.location.href = \'some location\'',
+            errors: [ {
+                message: 'Dangerous location.href assignment can lead to XSS.' +
+                    ' Please use escape(\'some location\') as a wrapper for escaping'
+            } ]
+        },
+        {
+            code: 'window.document.location.href = \'some location\'',
+            errors: [ {
+                message: 'Dangerous location.href assignment can lead to XSS.' +
+                    ' Please use escape(\'some location\') as a wrapper for escaping'
+            } ]
+        },
+        {
+            code: 'window.document.location.href = getNextUrl()',
+            errors: [ {
+                message: 'Dangerous location.href assignment can lead to XSS.' +
+                    ' Please use escape(getNextUrl()) as a wrapper for escaping'
+            } ]
+        }
+    ]
+} );


### PR DESCRIPTION
I think it's quite reasonable to have such rule enabled to prevent javascript URL based XSS attacks. 

Something like:
```js
var next = 'javascript:alert("hi xss")';
location.href = next;
```