### PR TITLE
feat: add memberExpression callee support to 'escapeFunc', such as 'DOMPurify.sanitize'.

### DIFF
--- a/lib/rules/no-location-href-assign.js
+++ b/lib/rules/no-location-href-assign.js
@@ -30,16 +30,16 @@ module.exports = {
                 }
                 var isLocationObject = left.object && left.object.name === 'location';
                 var isLocationProperty = left.object.property &&
-					left.object.property.name === 'location';
+                    left.object.property.name === 'location';
 
                 if( !( isLocationObject || isLocationProperty ) ) {
                     return;
                 }
 
-                if( node.right.callee && node.right.callee.name === escapeFunc ) {
+                var sourceCode = context.getSourceCode();
+                if( node.right.callee && ( node.right.callee.name === escapeFunc || sourceCode.getText( node.right.callee ) === escapeFunc ) ) {
                     return;
                 }
-                var sourceCode = context.getSourceCode();
                 var rightSource = sourceCode.getText( node.right );
                 var errorMsg = ERROR +
                     '. Please use ' + escapeFunc +

--- a/tests/lib/rules/no-location-href-assign.js
+++ b/tests/lib/rules/no-location-href-assign.js
@@ -17,6 +17,10 @@ ruleTester.run( 'no-location-href-assign', rule, {
         {
             code: 'location.href = escape(\'www\')',
             options: [ { escapeFunc: 'escape' } ]
+        },
+        {
+            code: 'location.href = DOMPurify.sanitize(\'www\')',
+            options: [ { escapeFunc: 'DOMPurify.sanitize' } ]
         }
     ],
 
@@ -43,6 +47,14 @@ ruleTester.run( 'no-location-href-assign', rule, {
             errors: [ {
                 message: 'Dangerous location.href assignment can lead to XSS.' +
                     ' Please use escape(\'some location\') as a wrapper for escaping'
+            } ]
+        },
+        {
+            code: 'location.href = \'some location for memberExpression callee\'',
+            options: [ { escapeFunc: 'DOMPurify.sanitize' } ],
+            errors: [ {
+                message: 'Dangerous location.href assignment can lead to XSS.' +
+                    ' Please use DOMPurify.sanitize(\'some location for memberExpression callee\') as a wrapper for escaping'
             } ]
         },
         {


### PR DESCRIPTION
Hi, Rantanen. Thanks for provide the so nice xss eslint plugin.

My project  uses 'DOMPurify.sanitize' to sanitize XSS attacks, and when I set 'escapeFunc' as 'DOMPurify.sanitize', 'no-location-href-assign' rule still throw error. So I fixed it when callee is  a memberExpression node 

Please review my commit .
If my code has any question, connact me, please. 
Thanks.