### PR TITLE
To work with the extends feature of .eslintrc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Tries to detect XSS issues in codebase before they end up in production.
 You'll first need to install [ESLint](http://eslint.org):
 
 ```
-$ npm i eslint --save-dev
+$ npm install eslint --save-dev
 ```
 
 Next, install `eslint-plugin-xss`:
@@ -42,6 +42,18 @@ Then configure the rules you want to use under the rules section.
     "rules": {
         "xss/rule-name": 2
     }
+}
+```
+
+Or:
+
+Enable all rules by adding the following to your `.eslintrc` configuration file
+
+```json
+{
+    "extends": [
+        "plugin:xss/recommended"
+    ]
 }
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,17 @@ var requireIndex = require( 'requireindex' );
 // Plugin Definition
 // -----------------------------------------------------------------------------
 
-
-// import all rules in lib/rules
-module.exports.rules = requireIndex( __dirname + '/rules' );
-
+module.exports = {
+  // import all rules in lib/rules
+  rules: requireIndex(__dirname + '/rules'),
+  // allow users to extend the recommended configurations
+  configs: {
+    recommended: {
+      plugins: ['xss'],
+      rules: {
+        'xss/no-mixed-html': 'error',
+        'xss/no-location-href-assign': 'error',
+      },
+    },
+  },
+};


### PR DESCRIPTION
Hi @Rantanen,

Most eslint plugins allow the user to work with the extends feature of .eslintrc files, so that they can simply extend our recommended configurations.

Therefore, this patch enable the avove feature in this awesome plugin.

For more information please see: [https://eslint.org/docs/latest/developer-guide/shareable-configs](https://eslint.org/docs/latest/developer-guide/shareable-configs)

Cheers,
Zhihui