### PR TITLE
Replacing escape function by encodeURI

### DIFF
--- a/docs/rules/no-location-href-assign.md
+++ b/docs/rules/no-location-href-assign.md
@@ -1,6 +1,6 @@
 # Checks for all assignments to location.href
 
-This rule ensures that you are calling escape logic before assigning to location.href property.
+This rule ensures that you are calling encodeURI logic before assigning to location.href property.
 
 ## Rule Details
 
@@ -26,13 +26,13 @@ location.href = getNextUrl();
 The following patterns are not errors:
 
 ```js
-// this rule ensures that you are calling escape function before location.href assignment
-// 'escape' name can be configured via options.
-location.href = escape('some evil url');
+// this rule ensures that you are calling encodeURI function before location.href assignment
+// 'encodeURI' name can be configured via options.
+location.href = encodeURI('some evil url');
 
 ```
 The concrete implementation of escape is up to you and how you will decide to escape location.href value. This rule
-only ensures that you are handling assignment in a proper way (by wrapping the right part with the escape function).
+only ensures that you are handling assignment in a proper way (by wrapping the right part with the encodeURI function).
 
 ### Options
 
@@ -43,7 +43,7 @@ only ensures that you are handling assignment in a proper way (by wrapping the r
 ```
 
 ### escapeFunc (optional)
-Function name that is used to sanitize user input. 'escape' is used by default.
+Function name that is used to sanitize user input. 'encodeURI' is used by default.
 
 
 ## When Not To Use It

--- a/lib/rules/no-location-href-assign.js
+++ b/lib/rules/no-location-href-assign.js
@@ -19,7 +19,7 @@ module.exports = {
     },
     create: function( context ) {
         var escapeFunc = context.options[ 0 ] &&
-            context.options[ 0 ].escapeFunc || 'escape';
+            context.options[ 0 ].escapeFunc || 'encodeURI';
 
         return {
             AssignmentExpression: function( node ) {

--- a/tests/lib/rules/no-location-href-assign.js
+++ b/tests/lib/rules/no-location-href-assign.js
@@ -15,8 +15,8 @@ ruleTester.run( 'no-location-href-assign', rule, {
         'someLink.href = \'www\'',
         'href = \'wwww\'',
         {
-            code: 'location.href = escape(\'www\')',
-            options: [ { escapeFunc: 'escape' } ]
+            code: 'location.href = encodeURI(\'www\')',
+            options: [ { escapeFunc: 'encodeURI' } ]
         },
         {
             code: 'location.href = DOMPurify.sanitize(\'www\')',
@@ -26,27 +26,27 @@ ruleTester.run( 'no-location-href-assign', rule, {
 
     invalid: [
         {
-            code: 'location.href = wrapper(escape(\'www\'))',
+            code: 'location.href = wrapper(encodeURI(\'www\'))',
             options: [ { escapeFunc: 'escapeXSS' } ],
             errors: [ {
                 message: 'Dangerous location.href assignment can lead to XSS.' +
-                ' Please use escapeXSS(wrapper(escape(\'www\'))) ' +
+                ' Please use escapeXSS(wrapper(encodeURI(\'www\'))) ' +
                 'as a wrapper for escaping'
             } ]
         },
         {
             code: 'location.href = wrapper(\'www\')',
-            options: [ { escapeFunc: 'escape' } ],
+            options: [ { escapeFunc: 'encodeURI' } ],
             errors: [ {
                 message: 'Dangerous location.href assignment can lead to XSS.' +
-                ' Please use escape(wrapper(\'www\')) as a wrapper for escaping'
+                ' Please use encodeURI(wrapper(\'www\')) as a wrapper for escaping'
             } ]
         },
         {
             code: 'location.href = \'some location\'',
             errors: [ {
                 message: 'Dangerous location.href assignment can lead to XSS.' +
-                    ' Please use escape(\'some location\') as a wrapper for escaping'
+                    ' Please use encodeURI(\'some location\') as a wrapper for escaping'
             } ]
         },
         {
@@ -61,28 +61,28 @@ ruleTester.run( 'no-location-href-assign', rule, {
             code: 'window.location.href = \'some location\'',
             errors: [ {
                 message: 'Dangerous location.href assignment can lead to XSS.' +
-                    ' Please use escape(\'some location\') as a wrapper for escaping'
+                    ' Please use encodeURI(\'some location\') as a wrapper for escaping'
             } ]
         },
         {
             code: 'document.location.href = \'some location\'',
             errors: [ {
                 message: 'Dangerous location.href assignment can lead to XSS.' +
-                    ' Please use escape(\'some location\') as a wrapper for escaping'
+                    ' Please use encodeURI(\'some location\') as a wrapper for escaping'
             } ]
         },
         {
             code: 'window.document.location.href = \'some location\'',
             errors: [ {
                 message: 'Dangerous location.href assignment can lead to XSS.' +
-                    ' Please use escape(\'some location\') as a wrapper for escaping'
+                    ' Please use encodeURI(\'some location\') as a wrapper for escaping'
             } ]
         },
         {
             code: 'window.document.location.href = getNextUrl()',
             errors: [ {
                 message: 'Dangerous location.href assignment can lead to XSS.' +
-                    ' Please use escape(getNextUrl()) as a wrapper for escaping'
+                    ' Please use encodeURI(getNextUrl()) as a wrapper for escaping'
             } ]
         }
     ]


### PR DESCRIPTION
Replacing the 'escape' function by encodeURI as the 'escape' function is now deprecated